### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simple_jucaml
-A very simple Jupiter kernel for OCaml
+A very simple Jupyter kernel for OCaml
 
 # Compilation
 You'll need `Yojson`, `Nocrypto` and `ZMQ` bindings for OCaml.  It also relies
@@ -10,12 +10,12 @@ on `Core.Time` and `Core.Uuid` packages.
     opam install nocrypto
     opam install ZMQ
 
-Native toplevel is not supported by OCaml, thus only bytecode compiation is possible. 
+Native toplevel is not supported by OCaml, thus only bytecode compilation is possible.
     
     corebuild jucaml.byte
 
 # Installation 
-Execute the next line to see in which directories your Jupyter to looks for kernels
+Check in which directories your Jupyter looks for kernels.
 
     python -c "import jupyter_client.kernelspec as j; print '\n'.join(j.KernelSpecManager().kernel_dirs)"
     
@@ -25,11 +25,11 @@ Execute the next line to see in which directories your Jupyter to looks for kern
     > /usr/share/jupyter/kernels
     > /home/user/.ipython/kernels
 
-Pick one of them, make a `jucaml` subdirectory there.
+Pick one of them and make a `jucaml` subdirectory there.
     
     mkdir -p /home/user/.local/share/jupyter/kernels/jucaml
 
-Finally, create a `kernel.json` with a path to the executable
+Finally, create a `kernel.json` with a path to the executable.
 
     cat > /home/user/.local/share/jupyter/kernels/jucaml/kernel.json << EOF
     {


### PR DESCRIPTION
Fix typos in README.md:
- Jupiter -> Jupyter
- compiation -> compilation
- extraneous "to"
- punctuation